### PR TITLE
NMRA2015 link correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,12 +292,12 @@ JMRI: A Java Model Railroad Interface
     	<h2>JMRI at NMRA Portland 2015 Convention</h2>
 		    <dl>
 		    <dt class="im">
-			<a href="http://www.nmra2015portland.org/taxonomy/term/61"><img src="http://www.nmra2015portland.org/sites/default/files/truck_logo.jpg" width="67" height="67"  alt="NMRA convention logo"></a>
+			<a href="http://nmra2015.sbcrailway.ca/taxonomy/term/61"><img src="http://www.nmra2015portland.org/sites/default/files/truck_logo.jpg" width="67" height="67"  alt="NMRA convention logo"></a>
 		    </dt>
 		    <dd>
 			We're planning a complete set of 
-			<a href="http://www.nmra2015portland.org/taxonomy/term/61">JMRI clinics</a> at the 
-			<a href="http://www.nmra2015portland.org/taxonomy/term/61">NMRA 2015 convention</a>
+			<a href="http://nmra2015.sbcrailway.ca/taxonomy/term/61">JMRI clinics</a> at the 
+			<a href="http://nmra2015.sbcrailway.ca/taxonomy/term/61">NMRA 2015 convention</a>
 			in Portland, along with our traditional user get-together.
 			<p>
 			Full descriptions and times are on the


### PR DESCRIPTION
NMRA2015 web site has moved to a new server, the URL in this page was updated.
