### PR TITLE
Repaired URL for 3.8 release notes

### DIFF
--- a/download/index.shtml
+++ b/download/index.shtml
@@ -168,7 +168,7 @@
 </a>
     <dt><a href="http://java.com/java/download/index.jsp?cid=jdp74834">Java</a></dt>
 	<dd>
-	    <p>Sun's Java Runtime support [<a href="http://java.com/java/download/index.jsp?cid=jdp74834">more</a>]</p>
+	    <p>Oracle Java Runtime support [<a href="http://java.com/java/download/index.jsp?cid=jdp74834">more</a>]</p>
 	</dd>
 
 	<dt class="im">
@@ -183,7 +183,7 @@
 	    <A HREF="http://home.comcast.net/~kb0oys/">CATS web site</a>.
 	    </p>
 	    <p>CATS 2.34 (Release2037) is compatible with JMRI 3.3.1 thru 3.8.
-	    We recommend that you use <a href="releasenotes/jmri3.8.shtml">JMRI 3.8 with it.</a>
+	    We recommend that you use <a href="../releasenotes/jmri3.8.shtml">JMRI 3.8 with it.</a>
 	    </p>
 	</dd>
     


### PR DESCRIPTION
At the bottom under CATS added ../ to the relative path to the 3.8 release notes. Changed Sun into Oracle in line 171.
