### PR TITLE
Cleanup ways to find download links

### DIFF
--- a/download/index.shtml
+++ b/download/index.shtml
@@ -79,8 +79,6 @@
 
 	    <a href="#prod-rel">Release 4.22</a> is the current "production" release, recommended
 	    for first-time users.
-
-
 	</dl>
 
   <div class="list">
@@ -89,27 +87,11 @@
     <dl>
     <dt class="im"><img src="../images/ico-jmri.gif" width="34" height="34" alt="JMRI logo"></dt>
     <dd>
-	<a id="prod-download"></a><p class="dl">Download:
-        <ul>
-        <li>OS X / macOS: <a
-            href="https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.dmg">https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.dmg</a><br/>
-          sha256: 55f9ac72f5452227a3949e363f9235f0d05e5a01d8d6224c90dc9dfbb87d0a0b </li>
-
-        <li>Windows: <a
-            href="https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.exe">https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.exe</a><br/>
-           sha256: ac71bfa05a13994e87ab5ba10f379ed77a8a1b5aad137afb9415f0ec23d10d52</li>
-
-        <li>Linux: <a
-            href="https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.tgz">https://github.com/JMRI/JMRI/releases/download/v4.22/JMRI.4.22+R4c4384d74.tgz</a><br/>
-           sha256: a63b8a9722efa4743fd5c6fddb881f1175154df700e75bb1658658a512fcfa45</li>
-        </ul>
-
-    <strong>Notes:</strong><br>
-    <p>For more information on the release contents, please see the
-    <a href="../releasenotes/jmri4.22.shtml">release note</a>.
-    </p>
-    <p>These files can be used for either a new installation or updating an existing installation.</p>
-    <p>We recommend that you verify the downloaded files using the provided sha256 key.</p>
+    	    <p>Release 4.22 is the current production release, recommended for first-time
+	    and casual users. It requires Java 8 (also known as 1.8). Please see the
+	    <a href="../releasenotes/jmri4.22.shtml">release note</A> for download and install
+	    information.</p>
+	    <p>Production release 4.22 was made available on March 1, 2021.</p>
     <p>
     If you're looking to download Rodney Black's
     <a href="http://cats4ctc.org"><!-- was http://home.comcast.net/~kb0oys/ --> CATS</a>
@@ -131,7 +113,7 @@
 	    run Java 1.6. Please see the
 	    <a href="../releasenotes/jmri3.10.1.shtml">release note</A> for download and install
 	    information.
-	    <p>Production release 3.10.1 was made available onn January 11, 2015.</p>
+	    <p>Production release 3.10.1 was made available on January 11, 2015.</p>
 
 	<div style="clear: both"></div>
     </dd>

--- a/index.shtml
+++ b/index.shtml
@@ -128,7 +128,7 @@
                     recent stable production release.</p>
                     <p>For more information, see the
                     <a href="releasenotes/jmri4.22.shtml">JMRI 4.22 Release Note</a>,
-                    which also contains the download links.</p>
+                    which also contains the <a href="releasenotes/jmri4.22.shtml">download links</a>.</p>
                 </div>
             </div>
 
@@ -143,7 +143,7 @@
                     <p>
                     For more information on this test release, please read the
                     <a href="releasenotes/jmri4.23.5.shtml">JMRI 4.23.5 Release Note</a>,
-                    which also contains the download links.
+                    which also contains the <a href="releasenotes/jmri4.23.5.shtml">download links</a>.
                     </p>
                     <a href="#download">Release 4.22</a> is the current "production" release, recommended
                     for first-time users.
@@ -160,7 +160,7 @@
                     that can only run Java 1.6; later releases require Java 1.8.</p>
                     <p>For more information, see the
                     <a href="releasenotes/jmri3.10.1.shtml">JMRI 3.10.1 Release Note</a>,
-                    which also contains the download links.</p>
+                    which also contains the <a href="releasenotes/jmri3.10.1.shtml">download links</a>.</p>
                 </div>
             </div>
 
@@ -174,7 +174,7 @@
                     that can only run Java 1.5; later releases require Java 1.6/1.8.</p>
                     <p>For more information, see the
                     <a href="releasenotes/jmri2.14.1.shtml">JMRI 2.14.1 Release Note</a>,
-                    which also contains the download links.</p>
+                    which also contains the <a href="releasenotes/jmri2.14.1.shtml">download links</a>.</p>
                 </div>
             </div>
         </div>

--- a/index.shtml
+++ b/index.shtml
@@ -122,7 +122,6 @@
             <div class="flex-item-50">
                 <h4 onclick="collapse('download1')" class="button card-1">JMRI 4.22 Production Release</h4>
                 <div id="download1" class="hidden">
-                    <p><a href="/download/index.shtml#prod-rel">Download 4.22</a></p>
                     Released on March 1, 2021.
                     <p>
                     JMRI 4.22 is recommended for new users. It is the most
@@ -136,7 +135,6 @@
             <div class="flex-item-50">
                 <h4 onclick="collapse('download2')" class="button card-1">JMRI 4.23.5 Test Release</h4>
                 <div id="download2" class="hidden">
-                    <p><a href="releasenotes/jmri4.23.5.shtml"></a></p>
                     Released on May 12, 2021.
                     <p>
                     This is the next in a series working toward the next JMRI production release 4.24
@@ -156,7 +154,6 @@
                 <h4 onclick="collapse('download3')" class="button card-1">JMRI 3.10.1 Production
                     Release</h4>
                 <div id="download3" class="hidden">
-                    <p><a href="releasenotes/jmri3.10.1.shtml"></a></p>
                     Released on January 11, 2015.
                     <p>
                     JMRI 3.10.1 is recommended for JMRI users with computers
@@ -171,7 +168,6 @@
                 <h4 onclick="collapse('download4')" class="button card-1">JMRI 2.14.1 Production
                     Release</h4>
                 <div id="download4" class="hidden">
-                    <p><a href="releasenotes/jmri2.14.1.shtml"></a></p>
                     Released on July 15, 2012.
                     <p>
                     JMRI 2.14.1 is recommended for JMRI users with computers


### PR DESCRIPTION
This is just a suggestion, trying to match the structure for all the different releases - as mentioned on jmri-developers