### PR TITLE
Convert 4.23.6 release note to draft

### DIFF
--- a/releasenotes/jmri4.23.6.shtml
+++ b/releasenotes/jmri4.23.6.shtml
@@ -23,13 +23,11 @@
       Release Notes for JMRI 4.23.6 release
       </h1>
 
-    <p>Date: May 12, 2021</p>
+    <p>Date: Upcoming</p>
     <p>From: Bob Jacobsen</p>
     <p>Subject: Test Release 4.23.6 of JMRI/DecoderPro is available for download.</p>
 
-<!--
 <p><b>This is a draft release note only; the download links do not yet work</b></p>
- -->
 
 <h2>Notes:</h2>
 


### PR DESCRIPTION
I was pretty much confused by the 4.23.6 release note as it showed up in the sidebar, just a few minutes ago.

Shouldn't it be clearer that it's a draft?

Heiko